### PR TITLE
hashref instead of a hash in W::H::H::WebSocket

### DIFF
--- a/lib/Web/Hippie.pm
+++ b/lib/Web/Hippie.pm
@@ -181,8 +181,8 @@ sub handler_ws {
 
             use Web::Hippie::Handle::WebSocket;
             $env->{'hippie.handle'} = Web::Hippie::Handle::WebSocket->new
-                ( id => $client_id,
-                  h  => $h );
+                ( {id => $client_id,
+                  h  => $h });
             $h->on_error( $self->connection_cleanup($env, $handler, $h) );
 
             my @keys = map {


### PR DESCRIPTION
small fix to prevent this:

use of hash in constructor is deprecated. use hashref please instead. at /Users/franck/perl5/perlbrew/perls/perl-5.12.2/lib/site_perl/5.12.2/Web/Hippie.pm line 183

thanks
