### PR TITLE
Constructor of Web::Hippie::Handle::WebSocket should be passed a hashref

### DIFF
--- a/lib/Web/Hippie.pm
+++ b/lib/Web/Hippie.pm
@@ -181,8 +181,8 @@ sub handler_ws {
 
             use Web::Hippie::Handle::WebSocket;
             $env->{'hippie.handle'} = Web::Hippie::Handle::WebSocket->new
-                ( id => $client_id,
-                  h  => $h );
+                ({ id => $client_id,
+                   h  => $h });
             $h->on_error( $self->connection_cleanup($env, $handler, $h) );
 
             my @keys = map {


### PR DESCRIPTION
Constructor of Web::Hippie::Handle::WebSocket should be passed a hashref. This will prevent a warning message that occurs because of this.
